### PR TITLE
Json typo

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -285,7 +285,7 @@ __Poznámka:__ Účet je pouze pro čtení, pro změny použijte prosím webové
         "vat_no": "CZ47123737",
         "bank_account": "",
         "iban": "",
-        "variable_symbol": "1234567890"
+        "variable_symbol": "1234567890",
         "full_name": "",
         "email": "",
         "email_copy": "",


### PR DESCRIPTION
Nevím jak ostatní knihovny, ale JAX-RS si s tímto překlepem neporadí. (org.codehaus.jackson.JsonParseException: Unexpected character ('"' (code 34)): was expecting comma to separate OBJECT entries)
