### PR TITLE
Added missing ES lang

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -954,7 +954,7 @@ Vyhledává se v následujících polích na fakturách: `name`, `full_name`,`em
 <tr><td>exchange_rate</td><td>kurz (povinný pokud je měna faktury jiná než měna účtu)</td><td>string, optional</td></tr>
 <tr><td>paypal</td><td>tlačítko pro platbu PayPalem - true/false</td><td>boolean, optional, default: false</td></tr>
 <tr><td>gopay</td><td>tlačítko pro platbu přes GoPay - true/false</td><td>boolean, optional, default: false</td></tr>
-<tr><td>language</td><td>jazyk faktury (cz, sk, en, de, fr, it, pl)</td><td>string, optional, default: cz</td></tr>
+<tr><td>language</td><td>jazyk faktury (cz, sk, en, de, fr, it, pl, es)</td><td>string, optional, default: cz</td></tr>
 <tr><td>transferred_tax_liability</td><td>přenesená daňová povinnost true/false</td><td>boolean, optional, default: false</td></tr>
 <tr><td>supply_code</td><td>kód plnění pro souhrnná hlášení (pouze pro zahraniční faktury do EU)</td><td>integer, optional</td></tr>
 <tr><td>eu_electronic_service</td><td>příznak, pokud je faktura v režimu MOSS</td><td>boolean, optional, default: false</td></tr>
@@ -2522,7 +2522,7 @@ Vyhledává se v následujících polích na nákladech: `number`, `variable_sym
 <tr><td>payment_method</td><td>bank (bankovní převod) / cash (hotově) / cod (dobírka) / card (Karta)</td><td>string, optional</td></tr>
 <tr><td>currency</td><td>kód měny (nepovinné - doplní se z účtu, 3 znaky)</td><td>string, optional, default: by account settings</td></tr>
 <tr><td>exchange_rate</td><td>kurz (nepovinné)</td><td>decimal, optional</td></tr>
-<tr><td>language</td><td>jazyk vystavené faktury (cz, sk, en, de, fr, it, pl)</td><td>string, optional, default: cz</td></tr>
+<tr><td>language</td><td>jazyk vystavené faktury (cz, sk, en, de, fr, it, pl, es)</td><td>string, optional, default: cz</td></tr>
 <tr><td>vat_price_mode</td><td>způsob zadávání cen do řádků</td><td>string, values: null, without_vat, with_vat</td></tr>
 <tr><td>transferred_tax_liability</td><td>přenesená daňová povinnost true/false</td><td>boolean, optional, default: false</td></tr>
 <tr><td>eu_electronic_service</td><td>příznak, pokud je faktura v režimu MOSS</td><td>boolean, optional, default: false</td></tr>


### PR DESCRIPTION
It turns out that fakturoid supports `ES` language when creating invoice, but is missing api docs.